### PR TITLE
emv/mpm: fix order of merchant account information sub-fields

### DIFF
--- a/emv/mpm/emv_types.go
+++ b/emv/mpm/emv_types.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -498,6 +499,9 @@ func (s *MerchantAccountInformation) String() string {
 	}
 	t := ""
 	t += s.GloballyUniqueIdentifier.String()
+	sort.Slice(s.PaymentNetworkSpecific, func(i, j int) bool {
+		return s.PaymentNetworkSpecific[i].Tag < s.PaymentNetworkSpecific[j].Tag
+	})
 	for _, pns := range s.PaymentNetworkSpecific {
 		t += pns.String()
 	}
@@ -823,8 +827,14 @@ func (c *EMVQR) GeneratePayload() string {
 	s := ""
 	s += c.PayloadFormatIndicator.String()
 	s += c.PointOfInitiationMethod.String()
-	for _, m := range c.MerchantAccountInformation {
-		s += m.String()
+	var keys []string
+	for k := range c.MerchantAccountInformation {
+		keys = append(keys, k.String())
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v, _ := c.MerchantAccountInformation[ID(k)]
+		s += v.String()
 	}
 	s += c.MerchantCategoryCode.String()
 	s += c.TransactionCurrency.String()

--- a/emv/mpm/emv_types_test.go
+++ b/emv/mpm/emv_types_test.go
@@ -442,7 +442,7 @@ func TestEMVQR_GeneratePayload(t *testing.T) {
 				MerchantAccountInformation: map[ID]MerchantAccountInformationTLV{
 					ID("02"): MerchantAccountInformationTLV{
 						Tag:    "02",
-						Length: "16",
+						Length: "32",
 						Value: &MerchantAccountInformation{
 							GloballyUniqueIdentifier: TLV{
 								Tag:    "00",
@@ -455,12 +455,22 @@ func TestEMVQR_GeneratePayload(t *testing.T) {
 									Length: "04",
 									Value:  "abcd",
 								},
+								TLV{
+									Tag:    "15",
+									Length: "04",
+									Value:  "efgh",
+								},
+								TLV{
+									Tag:    "13",
+									Length: "04",
+									Value:  "ijkl",
+								},
 							},
 						},
 					},
 				},
 			},
-			want:    "02160004hoge0104abcd" + formatCrc("02160004hoge0104abcd"),
+			want:    "02320004hoge0104abcd1304ijkl1504efgh" + formatCrc("02320004hoge0104abcd1304ijkl1504efgh"),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
When adding an element using `AddPaymentNetworkSpecific` order matters.

For example
```
merchAcctInfo := mpm.MerchantAccountInformation{}
merchAcctInfo.AddPaymentNetworkSpecific("04", "accountnumber123456")
merchAcctInfo.AddPaymentNetworkSpecific("01", "BANK12345")
```
this will generate merchant account information in this order 0419accountnumber1234560109BPIXXXi,
instead of "0109BANK123450419accountnumber123456".

Though, this is not issue when decoding the payload using this library
but it might cause issue for other parsers.

Also, fix ordering if there's multiple `MerchantAccountInformation`, golang maps iteration is not consistent. See golang maps iteration order https://blog.golang.org/maps